### PR TITLE
Fix Patch: Report Data 

### DIFF
--- a/report_data/serializers.py
+++ b/report_data/serializers.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 from rest_framework import serializers
-import report_data
 from report_data.models import ChangeLog, ReportData, Report, ReportFile, ReportDataChangeLog
 from mitigation_action.serializers import ContactSerializer
 from users.serializers import CustomUserSerializer

--- a/report_data/services.py
+++ b/report_data/services.py
@@ -358,7 +358,7 @@ class ReportDataService():
         return result
     
     def patch(self, request, report_data_id):
-        ## missing review and comments here!!
+
         data = request.data
         next_state, user = data.pop('fsm_state', None), request.user
         comment_list = data.pop('comments', [])
@@ -465,9 +465,9 @@ class ReportDataService():
         if report_data_status:
             review_number = report_data.review_count
             fsm_state = report_data.fsm_state
-            commet_list = report_data.comments.filter(review_number=review_number, fsm_state=fsm_state).all()
+            comment_list = report_data.comments.filter(review_number=review_number, fsm_state=fsm_state).all()
 
-            serialized_comment = CommentSerializer(commet_list, many=True)
+            serialized_comment = CommentSerializer(comment_list, many=True)
 
             result = (True, serialized_comment.data)
 
@@ -476,6 +476,7 @@ class ReportDataService():
 
         return result
 
+
     def get_comments_by_fsm_state_or_review_number(self, request, report_data_id, fsm_state=None, review_number=None):
         
         report_data_status, report_data = self._service_helper.get_one(ReportData, report_data_id)
@@ -483,9 +484,9 @@ class ReportDataService():
         if report_data_status:
 
             search_kwargs = {**search_key('fsm_state', fsm_state), **search_key('review_number', review_number)}
-            commet_list = report_data.comments.filter(**search_kwargs).all()
+            comment_list = report_data.comments.filter(**search_kwargs).all()
 
-            serialized_comment = CommentSerializer(commet_list, many=True)
+            serialized_comment = CommentSerializer(comment_list, many=True)
 
             result = (True, serialized_comment.data)
 

--- a/report_data/views.py
+++ b/report_data/views.py
@@ -30,7 +30,7 @@ def delete_report_data(request, pk):
 @has_permission_decorator('edit_report_data')
 def patch_report_data(request, pk):
     if request.method == 'PATCH':
-        result = view_helper.patch(pk, request)
+        result = view_helper.patch(request, pk)
     return result
 
 @api_view(['GET', 'DELETE', 'PUT', 'PATCH'])


### PR DESCRIPTION
# Summary

Fix `Patch` method of report data

## Description

The `Patch` method of report data was not working properly. This PR fixes it.
The `Patch` method is used to update the fsm state of a report data.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

- Review the code