### PR TITLE
AA, RD: Get ChangeLog

### DIFF
--- a/adaptation_action/services.py
+++ b/adaptation_action/services.py
@@ -27,6 +27,7 @@ class AdaptationActionServices():
         self.ACCESS_DENIED_ALL = "Access denied to all adaptation action registers"
         self.NO_INDICATOR = "The indicator id does not exist."
         self.NO_INDICATOR_MONITORING = "The indicator monitoring id does not exist."
+        self.CHANGE_LOG_NOT_FOUND = "Change log not found"
 
 
     def _create_sub_record(self, data, sub_record_name):
@@ -1687,4 +1688,16 @@ class AdaptationActionServices():
         else:
             result = (False, adap_action_data)
 
+        return result
+
+    def get_change_log_from_adaptation_action(self, request, adaptation_action_id):
+        result = (False, self.CHANGE_LOG_NOT_FOUND)
+        adaptation_action_status, adaptation_action_data = self._service_helper.get_one(AdaptationAction, adaptation_action_id)
+        
+        if adaptation_action_status:
+            change_log_list = adaptation_action_data.change_log.order_by('-date').all()
+            result = (True, ChangeLogSerializer(change_log_list, many=True).data)
+        else:
+            result = (False, adaptation_action_data)
+        
         return result

--- a/adaptation_action/urls.py
+++ b/adaptation_action/urls.py
@@ -122,4 +122,9 @@ urlpatterns = [
         views.get_benefited_population,
         name='get_benefited_population'
     ),
+    path(
+        'api/v1/adaptation-action/<uuid:adaptation_action_id>/change-log/',
+        views.get_change_log_from_adaptation_action,
+        name='get_change_log_from_adaptation_action'
+    ),
 ]

--- a/adaptation_action/views.py
+++ b/adaptation_action/views.py
@@ -302,3 +302,10 @@ def get_comments(request, adaptation_action_id, fsm_state=None, review_number=No
         result = view_helper.execute_by_name('get_comments_by_fsm_state_or_review_number', request, adaptation_action_id, fsm_state, review_number)
         
     return result
+
+@api_view(['GET'])
+def get_change_log_from_adaptation_action(request, adaptation_action_id=None):
+
+    if request.method == 'GET':
+        result = view_helper.execute_by_name("get_change_log_from_adaptation_action", request, adaptation_action_id)
+    return result

--- a/report_data/services.py
+++ b/report_data/services.py
@@ -25,6 +25,7 @@ class ReportDataService():
         self.STATE_HAS_NO_AVAILABLE_TRANSITIONS = "State has no available transitions."
         self.ACCESS_DENIED_ALL = "Access denied to all report data"
         self.ACCESS_DENIED = "Access denied to report data: {0}"
+        self.CHANGE_LOG_NOT_FOUND = "Change log not found"
 
 
     def _get_serialized_report_data(self,  data, report_data=None, partial=None):
@@ -507,3 +508,14 @@ class ReportDataService():
 
         return result
 
+    def get_change_log_from_report_data(self, request, report_data_id):
+        result = (False, self.CHANGE_LOG_NOT_FOUND)
+        report_status, report_data = self._service_helper.get_one(ReportData, report_data_id)
+        
+        if report_status:
+            change_log_list = report_data.change_log.order_by('-date').all()
+            result = (True, ChangeLogSerializer(change_log_list, many=True).data)
+        else:
+            result = (False, report_data)
+        
+        return result

--- a/report_data/urls.py
+++ b/report_data/urls.py
@@ -64,5 +64,9 @@ urlpatterns = [
         views.get_comments,
         name='get_comments'
     ),
-
+    path(
+        'api/v1/report-data/<int:report_data_id>/change-log/',
+        views.get_change_log_from_report_data,
+        name='get_change_log_from_report_data'
+    ),
 ]

--- a/report_data/views.py
+++ b/report_data/views.py
@@ -138,3 +138,10 @@ def get_comments(request, report_data_id, fsm_state=None, review_number=None):
         result = view_helper.execute_by_name('get_comments_by_fsm_state_or_review_number', request, report_data_id, fsm_state, review_number)
 
     return result
+
+@api_view(['GET'])
+def get_change_log_from_report_data(request, report_data_id=None):
+
+    if request.method == 'GET':
+        result = view_helper.execute_by_name("get_change_log_from_report_data", request, report_data_id)
+    return result


### PR DESCRIPTION
# Summary

New endpoints to get change logs

***Fixes # [issue](some-url)***

## Description

Create an endpoint to get all change logs from an adaptation action and report data

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

### Example GET

- **PATH**: *`base-url/api/v1/report-data/<int:report_data_id>/change-log/`*

<details>
<summary>Return</summary>

        [
          {
            "id": 13,
            "date": "2022-12-20T21:03:40.711711Z",
            "report_data": 6,
            "previous_status": "rejected_by_DCC",
            "current_status": "end",
            "user": 1
          },
          {
            "id": 12,
            "date": "2022-12-20T21:03:37.441072Z",
            "report_data": 6,
            "previous_status": "in_evaluation_by_DCC",
            "current_status": "rejected_by_DCC",
            "user": 1
          },
          {
            "id": 11,
            "date": "2022-12-20T21:00:17.350978Z",
            "report_data": 6,
            "previous_status": "submitted",
            "current_status": "in_evaluation_by_DCC",
            "user": 1
          },
          {
            "id": 10,
            "date": "2022-12-20T20:57:31.980832Z",
            "report_data": 6,
            "previous_status": "new",
            "current_status": "submitted",
            "user": 1
          }
        ]

</details>

- **PATH**: *`base-url/api/v1/adaptation-action/<uuid:adaptation_action_id>/change-log/`*

<details>
<summary>Return</summary>

        [
          {
            "id": 6,
            "date": "2023-03-27T22:09:26.406873Z",
            "adaptation_action": "a2c1816f-d408-491b-8c27-97dce5c6fbb4",
            "previous_status": "in_evaluation_by_DCC",
            "current_status": "accepted_by_DCC",
            "user": 1
          },
          {
            "id": 4,
            "date": "2023-01-30T21:48:54.306800Z",
            "adaptation_action": "a2c1816f-d408-491b-8c27-97dce5c6fbb4",
            "previous_status": "submitted",
            "current_status": "in_evaluation_by_DCC",
            "user": 1
          }
        ]

</details>
