### PR TITLE
[SIN-i125] style: modify response indicator

### DIFF
--- a/mitigation_action/serializers.py
+++ b/mitigation_action/serializers.py
@@ -452,13 +452,19 @@ class QAQCReductionEstimateQuestionSerializer(serializers.ModelSerializer):
 class MonitoringIndicatorSerializer(serializers.ModelSerializer):
 
     id = serializers.IntegerField()
-    indicator = serializers.SlugRelatedField(read_only=True, slug_field='name')
     class Meta:
         model = MonitoringIndicator
         fields = ('id', 'initial_date_report_period', 'final_date_report_period', 'data_updated_date', 'report_type', 'updated_data', 'report_line_text', 'web_service_conection', 'progress_report_period', 'progress_report_period_until', 'progress_report', 'indicator', 'monitoring_reporting_indicator')
         list_serializer_class = GenericListSerializer
-        
+    
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data['indicator'] = instance.indicator.name
+
+        return data
+
+        
 
 class IndicatorChangeLogSerializer(serializers.ModelSerializer):
 


### PR DESCRIPTION
# Summary

Changed how the `indicator` field is serialized in `IndicatorChangeLogSerializer` to improve API readability.

***Fixes # [125](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I125/details)***

## Description

Replaced the default `PrimaryKeyRelatedField` for the `indicator` field in `IndicatorChangeLogSerializer` with a `SlugRelatedField`, so the field now returns the `name` of the related `Indicator` instead of its ID.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

