### PR TITLE
[SIN-i76] feat: Cancel update

### DIFF
--- a/mitigation_action/_services.py
+++ b/mitigation_action/_services.py
@@ -999,19 +999,6 @@ class MitigationActionService():
             result = (impact_documentation_status, impact_documentation_data)
             
         return result
-        
-
-    def _should_cancel_update(self, user, mitigation_action):
-        
-        no_edit_states = ['submitted', 'in_evaluation_by_DCC', 'rejected_by_DCC', 'accepted_by_DCC']
-        if has_role(user,['admin']):
-            return False  
-        
-        if (has_role(user, ['information_provider_mitigation_action', 'information_provider'])):
-            if mitigation_action.fsm_state in no_edit_states:
-                return True
-
-        return False
 
 
     ## upload files in the models
@@ -1138,7 +1125,8 @@ class MitigationActionService():
         if not has_object_permission('access_mitigation_action_register', request.user, mitigation_action_data):
             return  (False, self.ACCESS_DENIED.format(mitigation_action_data.code))
         
-        if self._should_cancel_update(request.user, mitigation_action_data):
+        _workflow_service = WorkflowService(mitigation_action_data)
+        if _workflow_service._should_cancel_update(request.user):
             return (False, self.CANCEL_UPDATE.format(mitigation_action_data.code))
 
         if mitigation_action_status:

--- a/mitigation_action/workflow/services.py
+++ b/mitigation_action/workflow/services.py
@@ -5,6 +5,8 @@ from .states import States
 from .workflow import WorkFlow as MitigationActionWorkflow
 from django.contrib.auth.models import AbstractUser
 from viewflow.fsm import Transition
+from rolepermissions.checkers import has_role
+
 class MitigationActionWorkflowStep:
     
     workflow_state: MitigationActionWorkflow
@@ -106,3 +108,15 @@ class MitigationActionWorkflowStep:
             previous_status=previous_state,
             current_status=current_state
         )
+    
+    def _should_cancel_update(self, user):
+
+        no_edit_states = [States.SUBMITTED, States.IN_EVALUATION_BY_DCC, States.REJECTED_BY_DCC, States.ACCEPTED_BY_DCC]
+        if has_role(user,['admin']):
+            return False  
+        
+        if (has_role(user, ['information_provider_mitigation_action', 'information_provider'])):
+            if self.workflow_state.state in no_edit_states:
+                return True
+
+        return False


### PR DESCRIPTION
# Summary

Please include a summary of the changes and the related issue.

***Fixes # [i76](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I76)***

## Description

This change introduces a restriction that prevents users with the "Information Provider" role from editing records depending on the current status of the record.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

![image](https://github.com/user-attachments/assets/130ac8e0-e6bf-490b-a466-7d874d335235)
-PUT Admin role.

![image](https://github.com/user-attachments/assets/bc544bf6-7974-459b-a190-22283bd6cc24)
-PUT Information provider role.