### PR TITLE
[SIN-99][SIN-95] feat: new benefit data and restrictions for updating

### DIFF
--- a/adaptation_action/migrations/default_data/data_migration_0001_03.py
+++ b/adaptation_action/migrations/default_data/data_migration_0001_03.py
@@ -407,55 +407,59 @@ _benefited_population = [
         'code': '2'
     },
     {
-        'name': 'Niñez (menores de 12 años)',
+        'name': 'Hombres',
         'code': '3'
     },
     {
-        'name': 'Adolescentes (12- 18 años)',
+        'name': 'Niñez (menores de 12 años)',
         'code': '4'
     },
     {
-        'name': 'Jóvenes (12-35 años)',
+        'name': 'Adolescentes: 12 a 17 años.',
         'code': '5'
     },
     {
-        'name': 'Población adulta mayor',
+        'name': 'Jóvenes: 18 a 35 años.',
         'code': '6'
     },
     {
-        'name': 'Población con discapacidad',
+        'name': 'Población adulta mayor',
         'code': '7'
     },
     {
-        'name': 'Pueblos indígenas',
+        'name': 'Población con discapacidad',
         'code': '8'
     },
     {
-        'name': 'Población migrante',
+        'name': 'Pueblos indígenas',
         'code': '9'
     },
     {
-        'name': 'Población afrodescendiente',
+        'name': 'Población migrante',
         'code': '10'
     },
     {
-        'name': 'Población LGBTIQ+',
+        'name': 'Población afrodescendiente.',
         'code': '11'
     },
     {
-        'name': 'Población productora (ganadería, agricultura, pesca)',
+        'name': 'Población LGBTIQ+',
         'code': '12'
     },
     {
-        'name': 'Organizaciones de base comunitaria y grupos locales',
+        'name': 'Población productora (ganadería, agricultura, pesca)',
         'code': '13'
     },
     {
-        'name': 'Gobiernos locales',
+        'name': 'Organizaciones de base comunitaria y grupos locales',
         'code': '14'
     },
     {
-        'name': 'Otro',
+        'name': 'Gobiernos locales',
         'code': '15'
+    },
+    {
+        'name': 'Otro',
+        'code': '16'
     }
 ]

--- a/adaptation_action/services.py
+++ b/adaptation_action/services.py
@@ -29,6 +29,7 @@ class AdaptationActionServices():
         self.ACCESS_DENIED_ALL = "Access denied to all adaptation action registers"
         self.NO_INDICATOR = "The indicator id does not exist."
         self.NO_INDICATOR_MONITORING = "The indicator monitoring id does not exist."
+        self.CANCEL_UPDATE = "The update has been cancelled, the adaptation action {0} is not in a valid state to be updated."
 
 
     def _create_sub_record(self, data, sub_record_name):
@@ -1561,6 +1562,11 @@ class AdaptationActionServices():
 
         adaptation_action_status, adaptation_action_data = \
             self._service_helper.get_one(AdaptationAction, adaptation_action_id)
+        
+        _workflow_service = WorkflowService(adaptation_action_data)
+        if _workflow_service._should_cancel_update(request.user):
+            return (False, self.CANCEL_UPDATE.format(adaptation_action_data.code))
+        
         ## permission access return here
         if not has_object_permission('access_adaptation_action_register', request.user, adaptation_action_data):
             return  (False, self.ACCESS_DENIED.format(adaptation_action_data.id))

--- a/adaptation_action/workflow/services.py
+++ b/adaptation_action/workflow/services.py
@@ -2,6 +2,7 @@
 
 from django.contrib.auth.models import AbstractUser
 from viewflow.fsm import Transition
+from rolepermissions.checkers import has_role
 
 from adaptation_action.models import AdaptationAction, ChangeLog
 
@@ -106,3 +107,15 @@ class AdaptationActionWorkflowStep:
             previous_status=previous_state,
             current_status=current_state
         )
+
+    def _should_cancel_update(self, user):
+
+        no_edit_states = [States.SUBMITTED, States.IN_EVALUATION_BY_DCC, States.REJECTED_BY_DCC, States.ACCEPTED_BY_DCC]
+        if has_role(user,['admin']):
+            return False  
+        
+        if (has_role(user, ['information_provider_mitigation_action', 'information_provider'])):
+            if self.workflow_state.state in no_edit_states:
+                return True
+
+        return False


### PR DESCRIPTION
# Summary

Please include a summary of the changes and the related issue.

***Fixes # [i95](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I95/comments)***
***Fixes # [i99](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I99/comments)***

## Description

This change introduces a restriction that prevents users with the "Information Provider" role from editing records depending on the current status of the record.

Update _benefited_population catalog


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

<img width="2308" height="840" alt="image" src="https://github.com/user-attachments/assets/eb067d53-c3d7-4ad0-99b9-1642fc0c2315" />