### PR TITLE
[SIN-i108] Feat: Add/Update/Delete Indicators

### DIFF
--- a/adaptation_action/services.py
+++ b/adaptation_action/services.py
@@ -348,7 +348,7 @@ class AdaptationActionServices():
     
     def _get_serialized_indicator_adaptation(self, data, indicator_adaptation=None):
 
-        serializer = self._serializer_helper.get_serialized_record(IndicatorSerializer, data, record=indicator_adaptation)
+        serializer = self._serializer_helper.get_serialized_record(IndicatorSerializer, data, record=indicator_adaptation, partial=True)
 
         return serializer
 
@@ -1028,10 +1028,11 @@ class AdaptationActionServices():
             result = (False, error)
         
         return result
-    
-    
-    def _create_update_indicator(self, data, indicator_adaptation=None):
 
+
+    def _update_indicator(self, request, indicator_adaptation=None):
+        data = request.data.copy()
+        indicator_instance = IndicatorAdaptation.objects.filter(id=indicator_adaptation).first()
         fields = ['information_source', 'contact']
         validation_dict = {}
         for field in fields:
@@ -1044,14 +1045,14 @@ class AdaptationActionServices():
                 validation_dict.setdefault(record_status,[]).extend(dict_data)
     
         if all(validation_dict):
-
-            serialized_indicator_adaptation = self._get_serialized_indicator_adaptation(data, indicator_adaptation)
-                    
+            serialized_indicator_adaptation = self._get_serialized_indicator_adaptation(
+            data,
+            indicator_adaptation=indicator_instance
+        )
             if serialized_indicator_adaptation.is_valid():
                 indicator_adaptation = serialized_indicator_adaptation.save()
-
-                result = (True, indicator_adaptation)
-
+                result_data = IndicatorSerializer(indicator_instance).data
+                result = (True, result_data)
             else:
                 result = (False, serialized_indicator_adaptation.errors)
         else:
@@ -1059,7 +1060,15 @@ class AdaptationActionServices():
             
         return result
 
-    
+    def _delete_indicator(self, request, indicator_adaptation):
+        indicator_instance = IndicatorAdaptation.objects.filter(id=indicator_adaptation).first()
+        if indicator_instance:
+            indicator_instance.delete()
+            return (True, "Indicator deleted successfully")
+        else:
+            return (False, "Indicator not found")
+        
+
     def _get_indicator_monitoring_for_updating_creating(self, ind_monitoring_data_list, ind_monitoring_list, adaptation_action):
         
         for ind_monitoring_data in ind_monitoring_data_list:
@@ -1074,7 +1083,7 @@ class AdaptationActionServices():
             
         result = (True, ind_monitoring_data_list)
         
-        return result
+        return result 
 
         
     def _create_update_indicator_monitoring_list(self, indicator_monitoring_list_data, adaptation_action):
@@ -1159,7 +1168,7 @@ class AdaptationActionServices():
         if not adaptation_action_id:
             return (False, "Missing adaptation_action_id")
 
-        indicator_status, indicator_data = self._service_helper.get_one(IndicatorAdaptation, adaptation_action_id=adaptation_action_id)
+        indicator_status, indicator_data = self._service_helper.get_one(IndicatorAdaptation, record_id=adaptation_action_id)
         if indicator_status:
             result = (indicator_status, IndicatorSerializer(indicator_data).data)
         else:
@@ -1852,7 +1861,6 @@ class AdaptationActionServices():
     
     
     def update(self, request, adaptation_action_id):
-
         validation_dict = {}
         data = request.data.copy()
         indicator_list = data.pop('indicator_list', [])

--- a/adaptation_action/views.py
+++ b/adaptation_action/views.py
@@ -304,18 +304,20 @@ def get_comments(request, adaptation_action_id, fsm_state=None, review_number=No
     return result
 
 
-@api_view(['GET', 'PUT', 'POST'])
+@api_view(['GET', 'PUT', 'POST', 'DELETE'])
 @has_permission_decorator('read_adaptation_action')
-def get_put_indicator(request, adaptation_action_id=False):
-    if request.method == 'GET' and adaptation_action_id:
-        result = view_helper.execute_by_name('_get_indicator', request, adaptation_action_id)
+def get_put_indicator(request, indicator_id=False):
+    if request.method == 'GET' and indicator_id:
+        result = view_helper.execute_by_name('_get_indicator', request, indicator_id)
 
     elif request.method == 'PUT':
-        result = view_helper.execute_by_name('_create_update_indicator', request, adaptation_action_id)
+        result = view_helper.execute_by_name('_update_indicator', request, indicator_id)
 
     elif request.method == 'POST':
         result = view_helper.execute_by_name('_create_indicator', request)
 
+    elif request.method == 'DELETE' and indicator_id:
+        result = view_helper.execute_by_name('_delete_indicator', request, indicator_id)
     return result
 
 

--- a/docs/api/components/paths/general/record.yaml
+++ b/docs/api/components/paths/general/record.yaml
@@ -192,3 +192,81 @@ aa-create-indicator:
               $ref: '../../schemas/adaptation_actions.yaml#/AdaptationIndicator'
     security:
       - JWTAuth: []
+
+#Ejemplo: /adaptation-action/indicator/1/
+aa-get-update-indicator:
+  get:
+    tags:
+      - indicator
+    summary: Get a single indicator by its ID
+    parameters:
+      - in: path
+        name: id
+        description: The id of the indicator
+        required: true
+        schema:
+          type: integer
+          example: 1
+    responses:
+      '200':
+        description: Indicator details
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/adaptation_actions.yaml#/AdaptationIndicator'
+    security:
+    - JWTAuth: []
+  
+  put:
+    tags:
+      - indicator
+    summary: Update a single indicator by its ID
+    parameters:
+      - in: path
+        name: id
+        description: The id of the indicator
+        required: true
+        schema:
+          type: integer
+          example: 1
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/adaptation_actions.yaml#/AdaptationIndicator'
+    responses:
+      '200':
+        description: Indicator updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/adaptation_actions.yaml#/AdaptationIndicator'
+    security:
+      - JWTAuth: []
+  
+  delete:
+    tags:
+      - indicator
+    summary: Delete a single indicator by its ID
+    parameters:
+      - in: path
+        name: id
+        description: The id of the indicator
+        required: true
+        schema:
+          type: integer
+          example: 1
+    responses:
+      '200':
+        description: Indicator deleted successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Indicator deleted successfully
+    security:
+      - JWTAuth: []

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -83,6 +83,9 @@ paths:
   /adaptation-action/indicator/:
     $ref: "./components/paths/general/record.yaml#/aa-create-indicator"
 
+  /adaptation-action/indicator/{id}/:
+    $ref: "./components/paths/general/record.yaml#/aa-get-update-indicator"
+
 components:
   securitySchemes:
     JWTAuth:


### PR DESCRIPTION
# Summary

Allow adding multiple indicators to an adaptation action record

***Fixes # [i108](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I108/details)***

## Description

Implemented a full CRUD interface for Adaptation Action Indicators to support the creation, update, retrieval, and deletion of multiple indicators linked to a single adaptation action. 

This ensures that users can manage all related indicators for a given adaptation action record efficiently, fulfilling the requirements of the task.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

Se actualizó todo el CRUD de los indicadores para facilitar su uso en los registros

<img width="1475" height="288" alt="image" src="https://github.com/user-attachments/assets/a583d8d6-566c-416c-a36a-d25fa6a792bf" />


